### PR TITLE
fix(streaming): add missing f-prefix to phase_id on agent pause

### DIFF
--- a/sgr_agent_core/agents/dialog_agent.py
+++ b/sgr_agent_core/agents/dialog_agent.py
@@ -62,7 +62,7 @@ class DialogAgent(SGRToolCallingAgent):
             self.logger.info("\n⏸️  Research paused - please answer questions")
             self._context.state = AgentStatesEnum.WAITING_FOR_CLARIFICATION
             self.streaming_generator.finish(
-                phase_id="{self._context.iteration}-final", content=self._context.execution_result
+                phase_id=f"{self._context.iteration}-final", content=self._context.execution_result
             )
             self._context.clarification_received.clear()
             await self._context.clarification_received.wait()
@@ -73,7 +73,7 @@ class DialogAgent(SGRToolCallingAgent):
             self.logger.info("\n💬 Dialog shared - agent waiting for response")
             self._context.state = AgentStatesEnum.WAITING_FOR_CLARIFICATION
             self.streaming_generator.finish(
-                phase_id="{self._context.iteration}-final", content=self._context.execution_result
+                phase_id=f"{self._context.iteration}-final", content=self._context.execution_result
             )
             self._context.clarification_received.clear()
             await self._context.clarification_received.wait()

--- a/sgr_agent_core/base_agent.py
+++ b/sgr_agent_core/base_agent.py
@@ -246,7 +246,7 @@ class BaseAgent(AgentRegistryMixin):
         if isinstance(action_tool, ClarificationTool):
             self.logger.info("\n⏸️  Research paused - please answer questions")
             self.streaming_generator.finish(
-                phase_id="{self._context.iteration}-final", content=self._context.execution_result
+                phase_id=f"{self._context.iteration}-final", content=self._context.execution_result
             )
             self._context.clarification_received.clear()
             await self._context.clarification_received.wait()


### PR DESCRIPTION
## Problem

Three `streaming_generator.finish(...)` calls pass `phase_id` as a plain string that was meant to be an f-string:

```python
self.streaming_generator.finish(
    phase_id="{self._context.iteration}-final", content=self._context.execution_result
)
```

at `sgr_agent_core/base_agent.py:249` and `sgr_agent_core/agents/dialog_agent.py:65` and `:76`. Missing the `f` prefix, so the literal text `{self._context.iteration}-final` is sent verbatim instead of the interpolated `<iteration>-final`.

`phase_id` becomes the emitted SSE chunk's `id` (`OpenAIStreamingGenerator.finish` → `_create_base_chunk`, inherited by `OpenWebUIStreamingGenerator`). So the terminal streaming chunk on every agent pause/hand-off — the clarification path (`BaseAgent._execution_step`) and the DialogAgent `ClarificationTool` / `AnswerTool` "pass turn to user" paths (every DialogAgent turn) — ships a constant, invalid `id`.

The correct sibling in the same file proves intent — `base_agent.py:308` (the `finally`-block finish) already uses:

```python
phase_id=f"{self._context.iteration}-final", ...
```

## Reproduction

With `self._context.iteration == 3`:

- **Before:** emitted chunk `id` = `'{self._context.iteration}-final'` (literal)
- **After:** `id` = `'3-final'`

## Fix

Add the `f` prefix at the three sites:

```python
phase_id=f"{self._context.iteration}-final",
```

`python -m py_compile` passes for both files. (`tests/test_dialog_agent.py` already executes the `dialog_agent.py:76` pause path but doesn't assert `phase_id`, which is why the literal slipped through.)
